### PR TITLE
JeedouinoUSB: replace client.print by serial.print

### DIFF
--- a/sketchs/JeedouinoUSB.ino
+++ b/sketchs/JeedouinoUSB.ino
@@ -500,7 +500,7 @@ void loop()
 					if (pinTempo < 1 || pinTempo > 1000) pinTempo = 5;
 					ProbePauseDelay = 60000 * pinTempo;
 
-					client.print(F("SOK"));												// On reponds a JEEDOM
+					Serial.print(F("SOK"));												// On reponds a JEEDOM
 					jeedom+=F("&REP=SOK");
 				}
 			}


### PR DESCRIPTION
Seems there is an typo, and JeedouinoUSB try to use
ethernet client lib, even if it's not imported.

fix:
jiduino:503:11: error: 'client' was not declared in this scope
           client.print(F("SOK"));                       // On reponds a JEEDOM
           ^~~~~~